### PR TITLE
Gestió de dependències amb cpanfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# output files & folders
+dat/
+files/
+histogram.eps
+histogram.png
+qaf.db
+
+# cpanm
+cpanm

--- a/README.md
+++ b/README.md
@@ -2,27 +2,57 @@ Scripts per construir una base de dades de nomenaments d'ensenyament
 i exemple de representació gràfica d'un histograma de freqüències
 de nomenaments per servei territorial i especialitat.
 
-Com fer-lo servir:
+# Dependències
 
+Dependències de CPAN:
+- Statistics::Descriptive
+- DBI::SQlite
+- LWP::UserAgent
+
+Dependències externes:
+- Gnuplot
+- curl
+- Imagemagick
+
+
+# Com fer-lo servir:
+
+## Obté el codi font
+
+```
 git clone https://github.com/fr3ising/nomenaments.git
+```
 
+## Instal·la les dependències
+
+Del CPAN:
+
+```
+curl -LO http://xrl.us/cpanm
+perl cpanm --installdeps .
+```
+
+Del sistema operatiu:
+
+En sistemes Debian/Ubuntu:
+```
+sudo apt-get install curl imagemagick gnuplot
+```
+
+## Executa els scripts
+
+```
 mkdir files
 mkdir dat
 perl download.pl
 perl qaf_db.pl
+```
 
-La darrera comanda genera una base de dades sqlite anomenada qaf.db
+La darrera comanda genera una base de dades sqlite anomenada `qaf.db`.
 
-perl qaf_xpl.pl [CODI ESPECIALITAT] <- Opcional
+```
+perl qaf_xpl.pl [CODI ESPECIALITAT] # <- Opcional
+```
 
-Aquesta comanda genera un fitxer histogram.png amb la distribució
+Aquesta comanda genera un fitxer `histogram.png` amb la distribució
 de freqüències representada gràficament.
-
-Dependències de:
-
-- Statistics::Descriptive al CPAN
-- Gnuplot
-- DBI::SQlite
-- curl
-- LWP::UserAgent
-- Imagemagick

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Scripts per construïr una base de dades de nomenaments d'ensenyament
-i exemple de representació gràfica d'un histograma de freqüències
+Scripts per construir una base de dades de nomenaments d'ensenyament
+i exemple de representaciÃ³ grÃ fica d'un histograma de freqÃ¼Ã¨ncies
 de nomenaments per servei territorial i especialitat.
 
 Com fer-lo servir:
@@ -15,10 +15,10 @@ La darrera comanda genera una base de dades sqlite anomenada qaf.db
 
 perl qaf_xpl.pl [CODI ESPECIALITAT] <- Opcional
 
-Aquesta comanda genera un fitxer histogram.png amb la distribució
-de freqüències representada gràficament.
+Aquesta comanda genera un fitxer histogram.png amb la distribuciÃ³
+de freqÃ¼Ã¨ncies representada grÃ ficament.
 
-Dependències de:
+DependÃ¨ncies de:
 
 - Statistics::Descriptive al CPAN
 - Gnuplot
@@ -26,7 +26,3 @@ Dependències de:
 - curl
 - LWP::UserAgent
 - Imagemagick
-
-
-
-

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,3 @@
+requires 'Statistics::Descriptive', '==3.0613';
+requires 'CPAN::SQLite::DBI', '==0.211';
+requires 'LWP::UserAgent', '==6.33';


### PR DESCRIPTION
Creació del fitxer `cpanfile` i les instruccions de com fer servir [cpanm](https://metacpan.org/pod/cpanm) per instal·lar les dependències del [CPAN](https://www.cpan.org/).

A més:
- Creació del fitxer `.gitignore` per ignorar carpetes i fitxers de sortida
- Canvi del nom i edició del fitxer `README.md` canviant la seva codificació i afegint format i instruccions